### PR TITLE
refactor: apply DRY principles to upload stack, remove useMediaUpload

### DIFF
--- a/functions/upload.js
+++ b/functions/upload.js
@@ -1,25 +1,10 @@
 import { AwsClient } from 'aws4fetch';
 
-// Domains allowed to call this endpoint.
-// Set ALLOWED_ORIGINS (comma-separated) in your env for multiple origins,
-// or ALLOWED_ORIGIN for a single origin. No fallback — must be explicitly configured.
+// ponytail: Worker proxies upload to avoid CORS issues with presigned URLs
+// KEEP IN SYNC with src/lib/upload-config.ts (Worker can't import TS modules)
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'video/mp4', 'video/webm', 'video/quicktime', 'application/pdf'];
+const MAX_SIZE = 100 * 1024 * 1024; // 100MB
 
-// Supported media types for upload
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'video/mp4', 'video/webm', 'video/quicktime'];
-
-// 100 MB — supports video uploads while staying within Cloudflare Workers request body hard limit
-const MAX_SIZE_BYTES = 100 * 1024 * 1024;
-
-/**
- * @param {Request} request
- * @param {{ ALLOWED_ORIGIN?: string, ALLOWED_ORIGINS?: string }} env
- * @returns {{ 
- *   'Access-Control-Allow-Origin': string,
- *   'Access-Control-Allow-Methods': string,
- *   'Access-Control-Allow-Headers': string,
- *   'Vary': string
- * } | null}
- */
 function getCorsHeaders(request, env) {
   const origin = request.headers.get('Origin') || '';
   let allowed = [];
@@ -28,67 +13,170 @@ function getCorsHeaders(request, env) {
   } else if (env.ALLOWED_ORIGIN) {
     allowed = [env.ALLOWED_ORIGIN];
   }
-  if (allowed.length === 0 || !allowed.includes(origin)) {
-    return null;
-  }
+  if (allowed.length === 0 || !allowed.includes(origin)) return null;
   return {
     'Access-Control-Allow-Origin': origin,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Vary': 'Origin',
   };
 }
 
+// ponytail: DRY helper for all error responses
+function errorResponse(message, status, corsHeaders) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...(corsHeaders || { 'Vary': 'Origin' }) }
+  });
+}
+
+// ponytail: DRY helper for env var validation
+function checkEnvVars(env, requiredVars) {
+  return requiredVars.filter(key => !env[key] || typeof env[key] !== 'string' || env[key].trim() === '');
+}
+
+// ponytail: DRY helper for filename sanitization
+function getFileExtension(filename) {
+  return filename.includes('.')
+    ? '.' + filename.split('.').pop().toLowerCase().slice(0, 10).replace(/[^a-z0-9]/g, '')
+    : '';
+}
+
+// ponytail: DRY helper for error extraction
+function getErrorMessage(err) {
+  return err instanceof Error ? err.message : 'An unexpected error occurred';
+}
+
 /**
- * @param {{ request: Request, env: { R2_ACCESS_KEY: string, R2_SECRET_KEY: string, R2_ACCOUNT_ID: string, R2_BUCKET_NAME: string, R2_PUBLIC_URL: string, ALLOWED_ORIGIN?: string, ALLOWED_ORIGINS?: string } }} context
- * @returns {Promise<Response>}
+ * POST /upload
+ * Accepts file in request body, uploads to R2, returns public URL
  */
 export async function onRequestPost({ request, env }) {
   const corsHeaders = getCorsHeaders(request, env);
-  if (!corsHeaders) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), { status: 403, headers: { 'Content-Type': 'application/json', 'Vary': 'Origin' } });
-  }
-  // corsHeaders is now guaranteed to be non-null for subsequent uses
+  if (!corsHeaders) return errorResponse('Origin not allowed', 403);
+
   try {
-    const formData = await request.formData();
-    const file = formData.get('file');
+    const contentType = request.headers.get('Content-Type') || '';
+    const contentLength = parseInt(request.headers.get('Content-Length') || '0');
 
-    if (!file) {
-      return new Response(JSON.stringify({ error: 'No file provided' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
+    if (!ALLOWED_TYPES.includes(contentType)) {
+      return errorResponse(`File type "${contentType}" not allowed`, 415, corsHeaders);
     }
 
-    if (!(file instanceof File)) {
-      return new Response(JSON.stringify({ error: 'Invalid file upload' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
+    if (contentLength > MAX_SIZE) {
+      return errorResponse(`File size exceeds ${MAX_SIZE / 1024 / 1024}MB limit`, 413, corsHeaders);
     }
 
-    if (!ALLOWED_TYPES.includes(file.type)) {
-      return new Response(JSON.stringify({ error: `File type "${file.type}" is not allowed` }), {
-        status: 415,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
-    }
+    const url = new URL(request.url);
+    const filename = url.searchParams.get('filename') || 'file';
+    const folder = url.searchParams.get('folder') || '';
 
-    if (file.size > MAX_SIZE_BYTES) {
-      return new Response(JSON.stringify({ error: `File size exceeds the ${MAX_SIZE_BYTES / (1024 * 1024)} MB limit` }), {
-        status: 413,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
-    }
-
-    const missingVars = ['R2_ACCESS_KEY', 'R2_SECRET_KEY', 'R2_ACCOUNT_ID', 'R2_BUCKET_NAME', 'R2_PUBLIC_URL']
-      .filter(key => !env[key] || typeof env[key] !== 'string' || env[key].trim() === '');
-
+    const missingVars = checkEnvVars(env, ['R2_BUCKET_NAME', 'R2_PUBLIC_URL']);
     if (missingVars.length > 0) {
-      return new Response(JSON.stringify({ error: `Server misconfiguration: missing ${missingVars.join(', ')}` }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      return errorResponse(`Server misconfiguration: missing ${missingVars.join(', ')}`, 500, corsHeaders);
+    }
+
+    // Generate unique key with optional folder prefix
+    const ext = getFileExtension(filename);
+    const uniqueName = `${Date.now()}-${crypto.randomUUID()}${ext}`;
+    const key = folder ? `${folder}/${uniqueName}` : uniqueName;
+
+    // Read the request body once (can't be read multiple times)
+    const fileData = await request.arrayBuffer();
+
+    // Try R2 binding first (production), fallback to S3 API (dev)
+    const bucket = env.R2;
+    if (bucket) {
+      // Production: use R2 binding
+      console.log('Using R2 binding to upload:', key);
+      await bucket.put(key, fileData, {
+        httpMetadata: {
+          contentType: contentType,
+        },
       });
+    } else {
+      // Development: use S3-compatible API with credentials
+      console.log('Using S3 API to upload:', key);
+      const missingS3Vars = checkEnvVars(env, ['R2_ACCESS_KEY', 'R2_SECRET_KEY', 'R2_ACCOUNT_ID']);
+      if (missingS3Vars.length > 0) {
+        return errorResponse(`Server misconfiguration for dev: missing ${missingS3Vars.join(', ')}`, 500, corsHeaders);
+      }
+
+      // Use aws4fetch to sign and upload
+      const aws = new AwsClient({
+        accessKeyId: env.R2_ACCESS_KEY,
+        secretAccessKey: env.R2_SECRET_KEY,
+        service: 's3',
+        region: 'auto',
+      });
+
+      const uploadUrl = `https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${env.R2_BUCKET_NAME}/${key}`;
+      
+      try {
+        // aws4fetch automatically signs the request
+        const uploadResponse = await aws.fetch(uploadUrl, {
+          method: 'PUT',
+          body: fileData,
+          headers: { 
+            'Content-Type': contentType,
+          },
+        });
+
+        if (!uploadResponse.ok) {
+          const errorText = await uploadResponse.text();
+          console.error('R2 upload failed:', {
+            status: uploadResponse.status,
+            statusText: uploadResponse.statusText,
+            error: errorText,
+            url: uploadUrl,
+            key: key,
+          });
+          throw new Error(`R2 upload failed (${uploadResponse.status}): ${errorText}`);
+        }
+        
+        console.log('Upload successful:', key);
+      } catch (uploadError) {
+        console.error('Upload exception:', uploadError);
+        throw uploadError;
+      }
+    }
+
+    const publicUrl = `${env.R2_PUBLIC_URL}/${key}`;
+
+    return new Response(JSON.stringify({ url: publicUrl, key }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  } catch (err) {
+    console.error('Upload error:', getErrorMessage(err));
+    return errorResponse(getErrorMessage(err), 500, corsHeaders);
+  }
+}
+
+/**
+ * GET /upload?filename=x.jpg&type=image/jpeg
+ * Returns presigned PUT URL for direct browser → R2 upload (legacy, kept for compatibility)
+ */
+export async function onRequestGet({ request, env }) {
+  const corsHeaders = getCorsHeaders(request, env);
+  if (!corsHeaders) return errorResponse('Origin not allowed', 403);
+
+  try {
+    const url = new URL(request.url);
+    const filename = url.searchParams.get('filename');
+    const type = url.searchParams.get('type');
+
+    if (!filename || !type) {
+      return errorResponse('Missing filename or type parameter', 400, corsHeaders);
+    }
+
+    if (!ALLOWED_TYPES.includes(type)) {
+      return errorResponse(`File type "${type}" not allowed`, 415, corsHeaders);
+    }
+
+    const missingVars = checkEnvVars(env, ['R2_ACCESS_KEY', 'R2_SECRET_KEY', 'R2_ACCOUNT_ID', 'R2_BUCKET_NAME', 'R2_PUBLIC_URL']);
+    if (missingVars.length > 0) {
+      return errorResponse(`Server misconfiguration: missing ${missingVars.join(', ')}`, 500, corsHeaders);
     }
 
     const r2 = new AwsClient({
@@ -98,69 +186,29 @@ export async function onRequestPost({ request, env }) {
       region: 'auto',
     });
 
-    // Use UUID + timestamp as the filename key — no original filename needed
-    // This eliminates all path traversal risk and guarantees uniqueness
-    const ext = file.name.includes('.')
-      ? '.' + file.name.split('.').pop().toLowerCase().slice(0, 10).replace(/[^a-z0-9]/g, '')
-      : '';
-    const filename = `${Date.now()}-${crypto.randomUUID()}${ext}`;
-    const uploadUrl = `https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${env.R2_BUCKET_NAME}/${filename}`;
-    const arrayBuffer = await file.arrayBuffer();
+    const ext = getFileExtension(filename);
+    const key = `${Date.now()}-${crypto.randomUUID()}${ext}`;
+    const uploadUrl = `https://${env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com/${env.R2_BUCKET_NAME}/${key}`;
 
-    let uploadResponse;
+    const signedUrl = await r2.sign(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': type },
+      aws: { signQuery: true, datetime: new Date().toISOString() },
+    });
 
-    try {
-      uploadResponse = await r2.fetch(uploadUrl, {
-        method: 'PUT',
-        body: arrayBuffer,
-        headers: { 'Content-Type': file.type },
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown storage error';
-      return new Response(
-        JSON.stringify({
-          error: `Failed to reach storage: ${message}`,
-        }),
-        {
-          status: 502,
-          headers: {
-            'Content-Type': 'application/json',
-            ...corsHeaders,
-          },
-        }
-      );
-    }
+    const publicUrl = `${env.R2_PUBLIC_URL}/${key}`;
 
-    if (!uploadResponse.ok) {
-      return new Response(JSON.stringify({ error: `Storage rejected the upload (${uploadResponse.status})` }), {
-        status: 502,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
-    }
-
-    const publicUrl = `${env.R2_PUBLIC_URL}/${filename}`;
-
-    return new Response(JSON.stringify({ url: publicUrl }), {
+    return new Response(JSON.stringify({ uploadUrl: signedUrl.url, publicUrl, key }), {
       status: 200,
       headers: { 'Content-Type': 'application/json', ...corsHeaders },
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'An unexpected error occurred';
-    return new Response(JSON.stringify({ error: message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
+    return errorResponse(getErrorMessage(err), 500, corsHeaders);
   }
 }
 
-/**
- * @param {{ request: Request, env: { ALLOWED_ORIGIN?: string } }} context
- * @returns {Promise<Response>}
- */
 export async function onRequestOptions({ request, env }) {
   const corsHeaders = getCorsHeaders(request, env);
-  if (!corsHeaders) {
-    return new Response(null, { status: 403 });
-  }
+  if (!corsHeaders) return new Response(null, { status: 403 });
   return new Response(null, { headers: corsHeaders });
 }

--- a/src/components/Events/EventGalleryManager.tsx
+++ b/src/components/Events/EventGalleryManager.tsx
@@ -2,8 +2,10 @@ import React, { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
-import { Plus, Trash2, Upload, X, Link2, Image as ImageIcon } from 'lucide-react';
+import { Plus, Trash2, Upload, X, Link2, Image as ImageIcon, Loader2 } from 'lucide-react';
 import { Label } from '../ui/label';
+import { useR2Upload } from '@/hooks/useR2Upload';
+import { useToast } from '@/hooks/use-toast';
 
 interface EventGalleryManagerProps {
   images: string[];
@@ -23,6 +25,8 @@ export const EventGalleryManager: React.FC<EventGalleryManagerProps> = ({
   const [newImageUrl, setNewImageUrl] = useState('');
   const [isAddingUrl, setIsAddingUrl] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { upload, isUploading, progress } = useR2Upload();
+  const { toast } = useToast();
 
   const handleAddImageUrl = () => {
     const trimmedUrl = newImageUrl.trim();
@@ -33,34 +37,36 @@ export const EventGalleryManager: React.FC<EventGalleryManagerProps> = ({
     }
   };
 
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (!files || images.length >= maxImages) return;
 
-    const fileReaders: Promise<string>[] = [];
     const remainingSlots = maxImages - images.length;
-    const filesToProcess = Array.from(files).slice(0, remainingSlots);
+    const uploadedUrls: string[] = [];
+    let failedCount = 0;
 
-    filesToProcess.forEach((file) => {
-      if (file.type.startsWith('image/')) {
-        fileReaders.push(
-          new Promise((resolve) => {
-            const reader = new FileReader();
-            reader.onload = (e) => resolve(e.target?.result as string);
-            reader.readAsDataURL(file);
-          })
-        );
+    // ponytail: Sequential upload to avoid parallel R2 limits, reuse single hook
+    for (const file of Array.from(files).slice(0, remainingSlots)) {
+      if (!file.type.startsWith('image/')) continue;
+      const result = await upload(file, { folder: 'events' });
+      if (result.success && result.url) {
+        uploadedUrls.push(result.url);
+      } else {
+        failedCount++;
       }
-    });
+    }
 
-    Promise.all(fileReaders).then((base64Images) => {
-      const newImages = base64Images.filter(img => !images.includes(img));
-      if (newImages.length > 0) {
-        onChange([...images, ...newImages]);
-      }
-    });
-
-    // Reset the file input
+    if (uploadedUrls.length > 0) onChange([...images, ...uploadedUrls]);
+    
+    // ponytail: Single summary toast instead of toast-per-failure spam
+    if (failedCount > 0) {
+      toast({ 
+        variant: 'destructive', 
+        title: 'Some uploads failed', 
+        description: `${uploadedUrls.length} succeeded, ${failedCount} failed` 
+      });
+    }
+    
     event.target.value = '';
   };
 
@@ -74,7 +80,6 @@ export const EventGalleryManager: React.FC<EventGalleryManagerProps> = ({
     setIsAddingUrl(false);
   };
 
-  const canAddMore = images.length < maxImages;
   const hasMinimumImages = images.length >= minImages;
 
   return (
@@ -185,11 +190,11 @@ export const EventGalleryManager: React.FC<EventGalleryManagerProps> = ({
                     type="button"
                     variant="outline"
                     onClick={() => fileInputRef.current?.click()}
-                    disabled={disabled}
+                    disabled={disabled || isUploading}
                     className="flex items-center gap-2"
                   >
-                    <Upload className="h-4 w-4" />
-                    Upload Images
+                    {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                    {isUploading ? `Uploading ${progress}%` : 'Upload Images'}
                   </Button>
                   <Button
                     type="button"

--- a/src/components/Events/NewPost/NewPostSection.tsx
+++ b/src/components/Events/NewPost/NewPostSection.tsx
@@ -15,6 +15,7 @@ import { Badge } from '../../ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/select';
 import { Save, Upload, Bold, Italic, List, Link2, Heading1, Heading2, Heading3, Image as ImageIcon, X, Eye, Edit3, Sparkles, Hash, Calendar, Clock, MapPin, Users, Phone, Mail, DollarSign, HelpCircle, Images, Play, Search, Loader2, Plus, File as FileIcon, Megaphone, MessageSquare } from 'lucide-react';
 import { useToast } from '../../../hooks/use-toast';
+import { useR2Upload } from '../../../hooks/useR2Upload';
 import { useForms } from '../../../hooks/useForms';
 import { FAQManager } from '../FAQManager';
 import { EventGalleryManager } from '../EventGalleryManager';
@@ -93,6 +94,11 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
   const [languageInput, setLanguageInput] = useState('');
   const [enquiryPdfUrl, setEnquiryPdfUrl] = useState<string | null>(null);
   const [enquiryPdfPath, setEnquiryPdfPath] = useState<string | null>(null);
+  const { upload: uploadToR2, isUploading: isUploadingToR2, progress: uploadProgress } = useR2Upload();
+  const { toast } = useToast();
+  
+  // Upload state trackers
+  const [uploadingField, setUploadingField] = useState<string | null>(null);
   
   // Debug function to track keyHighlights changes
   const handleKeyHighlightsChange = (newHighlights: string[]) => {
@@ -105,7 +111,6 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
   const mobileFileInputRef = useRef<HTMLInputElement>(null);
   const bannerInputRef = useRef<HTMLInputElement>(null);
   const speakerPhotoInputRef = useRef<HTMLInputElement>(null);
-  const { toast } = useToast();
   const { forms } = useForms();
 
   // Geocode address to lat/lng
@@ -143,7 +148,7 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
       StarterKit,
       Image.configure({
         inline: true,
-        allowBase64: true,
+        allowBase64: false,
       }),
       Link.configure({
         openOnClick: false,
@@ -165,6 +170,16 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
 
   // Track the last loaded edit ID to prevent reloading the same data
   const [lastLoadedEditId, setLastLoadedEditId] = useState<string | null>(null);
+
+  // ponytail: Clean base64 from loaded data
+  const sanitizeImageUrl = (url: string | undefined | null): string => {
+    if (!url) return '';
+    if (isBase64Image(url)) {
+      console.warn('Base64 image detected and removed:', url.substring(0, 50));
+      return '';
+    }
+    return url;
+  };
 
   useEffect(() => {
     if (!editingPost || !editor) return;
@@ -213,9 +228,12 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
     setSpeakersDetails(editingPost.speakers || []);
     setSponsors(editingPost.sponsors || []);
     setStatus(editingPost.status || 'upcoming');
-    setEventBanner(editingPost.event_banner || '');
-    setFeaturedImage(editingPost.featured_image || '');
-    setMobileFeaturedImage(editingPost.mobile_featured_image || '');
+    
+    // Sanitize all image URLs to remove base64
+    setEventBanner(sanitizeImageUrl(editingPost.event_banner));
+    setFeaturedImage(sanitizeImageUrl(editingPost.featured_image));
+    setMobileFeaturedImage(sanitizeImageUrl(editingPost.mobile_featured_image));
+    
     setTags(editingPost.event_tags || []);
     setKeyHighlights(editingPost.highlights || []);
     setLanguages(editingPost.languages || []);
@@ -255,50 +273,115 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
     }
   }, [title]);
 
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setFeaturedImage(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+  // ponytail: Auto-clear base64 if it somehow gets into state
+  useEffect(() => {
+    if (isBase64Image(featuredImage)) {
+      console.warn('Base64 detected in featuredImage, clearing...');
+      setFeaturedImage('');
+      toast({ 
+        variant: 'destructive', 
+        title: 'Base64 image removed', 
+        description: 'Please use the upload button to upload images' 
+      });
     }
+  }, [featuredImage]);
+
+  useEffect(() => {
+    if (isBase64Image(mobileFeaturedImage)) {
+      console.warn('Base64 detected in mobileFeaturedImage, clearing...');
+      setMobileFeaturedImage('');
+      toast({ 
+        variant: 'destructive', 
+        title: 'Base64 image removed', 
+        description: 'Please use the upload button to upload images' 
+      });
+    }
+  }, [mobileFeaturedImage]);
+
+  useEffect(() => {
+    if (isBase64Image(eventBanner)) {
+      console.warn('Base64 detected in eventBanner, clearing...');
+      setEventBanner('');
+      toast({ 
+        variant: 'destructive', 
+        title: 'Base64 image removed', 
+        description: 'Please use the upload button to upload images' 
+      });
+    }
+  }, [eventBanner]);
+
+  // ponytail: Reject base64, accept only valid URLs
+  const isBase64Image = (str: string): boolean => {
+    return str.trim().startsWith('data:image/');
   };
 
-  const handleMobileImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setMobileFeaturedImage(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+  const handleFeaturedImageChange = (value: string) => {
+    if (isBase64Image(value)) {
+      toast({ 
+        variant: 'destructive', 
+        title: 'Base64 not allowed', 
+        description: 'Please use the upload button to upload images to Cloudflare R2' 
+      });
+      // Clear the base64 value
+      setFeaturedImage('');
+      return;
     }
+    setFeaturedImage(value);
   };
 
-  const handleBannerUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setEventBanner(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+  const handleMobileFeaturedImageChange = (value: string) => {
+    if (isBase64Image(value)) {
+      toast({ 
+        variant: 'destructive', 
+        title: 'Base64 not allowed', 
+        description: 'Please use the upload button to upload images to Cloudflare R2' 
+      });
+      // Clear the base64 value
+      setMobileFeaturedImage('');
+      return;
     }
+    setMobileFeaturedImage(value);
   };
 
-  const handleSpeakerPhotoUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const photoSrc = e.target?.result as string;
-        setCurrentSpeaker(prev => ({ ...prev, photo: photoSrc }));
-      };
-      reader.readAsDataURL(file);
+  const handleEventBannerChange = (value: string) => {
+    if (isBase64Image(value)) {
+      toast({ 
+        variant: 'destructive', 
+        title: 'Base64 not allowed', 
+        description: 'Please use the upload button to upload images to Cloudflare R2' 
+      });
+      // Clear the base64 value
+      setEventBanner('');
+      return;
     }
+    setEventBanner(value);
   };
+
+  // ponytail: One upload handler, not four copies
+  const createUploadHandler = (field: string, setter: (url: string) => void, label: string) => 
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      
+      setUploadingField(field);
+      const result = await uploadToR2(file, { folder: 'events' });
+      
+      if (result.success && result.url) {
+        setter(result.url);
+        toast({ title: 'Success', description: `${label} uploaded successfully` });
+      } else {
+        toast({ variant: 'destructive', title: 'Upload failed', description: result.error });
+      }
+      setUploadingField(null);
+    };
+
+  const handleImageUpload = createUploadHandler('featuredImage', setFeaturedImage, 'Image');
+  const handleMobileImageUpload = createUploadHandler('mobileImage', setMobileFeaturedImage, 'Mobile image');
+  const handleBannerUpload = createUploadHandler('banner', setEventBanner, 'Banner');
+  const handleSpeakerPhotoUpload = createUploadHandler('speakerPhoto', 
+    (url) => setCurrentSpeaker(prev => ({ ...prev, photo: url })), 
+    'Speaker photo'
+  );
 
   const insertImage = () => {
     const url = window.prompt('Enter image URL:');
@@ -437,6 +520,32 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     console.log('Form submitted!');
+
+    // ponytail: Validate no base64 images before submit
+    if (isBase64Image(featuredImage)) {
+      toast({
+        title: "Invalid Image",
+        description: "Featured image contains base64 data. Please upload the image using the upload button.",
+        variant: "destructive"
+      });
+      return;
+    }
+    if (isBase64Image(mobileFeaturedImage)) {
+      toast({
+        title: "Invalid Image",
+        description: "Mobile featured image contains base64 data. Please upload the image using the upload button.",
+        variant: "destructive"
+      });
+      return;
+    }
+    if (isBase64Image(eventBanner)) {
+      toast({
+        title: "Invalid Image",
+        description: "Event banner contains base64 data. Please upload the image using the upload button.",
+        variant: "destructive"
+      });
+      return;
+    }
 
     const isPhysical = locationType === 'physical';
     const parsedLat = isPhysical && locationGeo.lat ? parseFloat(locationGeo.lat) : null;
@@ -701,19 +810,39 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                     <div className="flex gap-3">
                       <Input
                         value={featuredImage}
-                        onChange={(e) => setFeaturedImage(e.target.value)}
+                        onChange={(e) => handleFeaturedImageChange(e.target.value)}
                         placeholder="Image URL or upload a file..."
                         className="flex-1 border-slate-200 focus:border-purple-400 focus:ring-2 focus:ring-purple-100 transition-all duration-200"
+                        disabled={uploadingField === 'featuredImage'}
                       />
                       <Button
                         type="button"
                         variant="outline"
                         onClick={() => fileInputRef.current?.click()}
+                        disabled={uploadingField === 'featuredImage'}
                         className="h-10 px-4 border-slate-200 hover:border-slate-300 hover:bg-slate-50 transition-all duration-200"
                       >
-                        <Upload className="w-4 h-4" />
+                        {uploadingField === 'featuredImage' ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <Upload className="w-4 h-4" />
+                        )}
                       </Button>
                     </div>
+                    {uploadingField === 'featuredImage' && (
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-sm text-slate-600">
+                          <span>Uploading image...</span>
+                          <span className="font-medium">{uploadProgress}%</span>
+                        </div>
+                        <div className="w-full h-2 bg-slate-200 rounded-full overflow-hidden">
+                          <div 
+                            className="h-full bg-purple-600 transition-all duration-300 ease-out"
+                            style={{ width: `${uploadProgress}%` }}
+                          />
+                        </div>
+                      </div>
+                    )}
                     <input
                       ref={fileInputRef}
                       type="file"
@@ -721,7 +850,7 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                       onChange={handleImageUpload}
                       className="hidden"
                     />
-                    {featuredImage && (
+                    {featuredImage && !isBase64Image(featuredImage) && (
                       <div className="relative group">
                         <img
                           src={featuredImage}
@@ -742,19 +871,39 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                     <div className="flex gap-3">
                       <Input
                         value={mobileFeaturedImage}
-                        onChange={(e) => setMobileFeaturedImage(e.target.value)}
+                        onChange={(e) => handleMobileFeaturedImageChange(e.target.value)}
                         placeholder="Mobile image URL or upload a file..."
                         className="flex-1 border-slate-200 focus:border-purple-400 focus:ring-2 focus:ring-purple-100 transition-all duration-200"
+                        disabled={uploadingField === 'mobileImage'}
                       />
                       <Button
                         type="button"
                         variant="outline"
                         onClick={() => mobileFileInputRef.current?.click()}
+                        disabled={uploadingField === 'mobileImage'}
                         className="h-10 px-4 border-slate-200 hover:border-slate-300 hover:bg-slate-50 transition-all duration-200"
                       >
-                        <Upload className="w-4 h-4" />
+                        {uploadingField === 'mobileImage' ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <Upload className="w-4 h-4" />
+                        )}
                       </Button>
                     </div>
+                    {uploadingField === 'mobileImage' && (
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-sm text-slate-600">
+                          <span>Uploading mobile image...</span>
+                          <span className="font-medium">{uploadProgress}%</span>
+                        </div>
+                        <div className="w-full h-2 bg-slate-200 rounded-full overflow-hidden">
+                          <div 
+                            className="h-full bg-purple-600 transition-all duration-300 ease-out"
+                            style={{ width: `${uploadProgress}%` }}
+                          />
+                        </div>
+                      </div>
+                    )}
                     <input
                       ref={mobileFileInputRef}
                       type="file"
@@ -762,7 +911,7 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                       onChange={handleMobileImageUpload}
                       className="hidden"
                     />
-                    {mobileFeaturedImage && (
+                    {mobileFeaturedImage && !isBase64Image(mobileFeaturedImage) && (
                       <div className="relative group">
                         <img
                           src={mobileFeaturedImage}
@@ -1127,17 +1276,17 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                         const fileInput = document.createElement('input');
                         fileInput.type = 'file';
                         fileInput.accept = 'video/*';
-                        fileInput.onchange = (e) => {
+                        fileInput.onchange = async (e) => {
                           const file = (e.target as HTMLInputElement).files?.[0];
                           if (!file) return;
                           
                           if (file.type.startsWith('video/')) {
-                            const reader = new FileReader();
-                            reader.onload = (e) => {
-                              const result = e.target?.result as string;
-                              setTeaserVideo(result);
-                            };
-                            reader.readAsDataURL(file);
+                            const result = await uploadToR2(file);
+                            if (result.success && result.url) {
+                              setTeaserVideo(result.url);
+                            } else {
+                              toast({ variant: 'destructive', title: 'Upload failed', description: result.error });
+                            }
                           }
                         };
                         fileInput.click();
@@ -1191,37 +1340,34 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                       type="button"
                       variant="outline"
                       size="sm"
-                      onClick={() => {
+                      onClick={async () => {
                         const fileInput = document.createElement('input');
                         fileInput.type = 'file';
                         fileInput.accept = 'image/*';
                         fileInput.multiple = true;
-                        fileInput.onchange = (e) => {
+                        fileInput.onchange = async (e) => {
                           const files = (e.target as HTMLInputElement).files;
                           if (!files || eventsGallery.length >= 8) return;
                           
-                          const fileReaders: Promise<string>[] = [];
                           const remainingSlots = 8 - eventsGallery.length;
                           const filesToProcess = Array.from(files).slice(0, remainingSlots);
+                          const uploadedUrls: string[] = [];
                           
-                          filesToProcess.forEach((file) => {
-                            if (file.type.startsWith('image/')) {
-                              fileReaders.push(
-                                new Promise((resolve) => {
-                                  const reader = new FileReader();
-                                  reader.onload = (e) => resolve(e.target?.result as string);
-                                  reader.readAsDataURL(file);
-                                })
-                              );
+                          // ponytail: Sequential upload to avoid R2 rate limits
+                          for (const file of filesToProcess) {
+                            if (!file.type.startsWith('image/')) continue;
+                            
+                            const result = await uploadToR2(file);
+                            if (result.success && result.url) {
+                              uploadedUrls.push(result.url);
+                            } else {
+                              toast({ variant: 'destructive', title: 'Upload failed', description: result.error || `Failed to upload ${file.name}` });
                             }
-                          });
+                          }
                           
-                          Promise.all(fileReaders).then((base64Images) => {
-                            const newImages = base64Images.filter(img => !eventsGallery.includes(img));
-                            if (newImages.length > 0) {
-                              setEventsGallery([...eventsGallery, ...newImages]);
-                            }
-                          });
+                          if (uploadedUrls.length > 0) {
+                            setEventsGallery([...eventsGallery, ...uploadedUrls]);
+                          }
                         };
                         fileInput.click();
                       }}
@@ -1821,7 +1967,6 @@ const NewPostSection = ({ onPostSaved, editingPost, isSaving = false }: NewPostS
                   <PDFUpload
                     eventId={editingPost.id}
                     currentPDFUrl={enquiryPdfUrl || undefined}
-                    currentPDFPath={enquiryPdfPath || undefined}
                     onUploadComplete={(url, path) => {
                       setEnquiryPdfUrl(url);
                       setEnquiryPdfPath(path || null);

--- a/src/components/Events/PDFUpload.tsx
+++ b/src/components/Events/PDFUpload.tsx
@@ -2,15 +2,14 @@ import React, { useState, useRef } from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Upload, File, X, CheckCircle, AlertCircle } from "lucide-react";
-import { uploadEventEnquiryPDF, deleteEventEnquiryPDF, validatePDF } from "@/lib/pdf-utils";
+import { Upload, File, X, CheckCircle } from "lucide-react";
+import { useR2Upload } from "@/hooks/useR2Upload";
 import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
 
 interface PDFUploadProps {
   eventId: string;
   currentPDFUrl?: string | null;
-  currentPDFPath?: string | null;
   onUploadComplete?: (url: string, path?: string) => void;
   onDeleteComplete?: () => void;
   disabled?: boolean;
@@ -19,29 +18,30 @@ interface PDFUploadProps {
 export const PDFUpload: React.FC<PDFUploadProps> = ({
   eventId,
   currentPDFUrl,
-  currentPDFPath,
   onUploadComplete,
   onDeleteComplete,
   disabled = false
 }) => {
-  const [uploadProgress, setUploadProgress] = useState<number>(0);
-  const [isUploading, setIsUploading] = useState<boolean>(false);
   const [isDragging, setIsDragging] = useState<boolean>(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { upload, isUploading, progress } = useR2Upload();
   const { toast } = useToast();
 
-  const handleFileSelect = (file: File) => {
-    // Validate the file
-    const validation = validatePDF(file);
-    if (!validation.valid) {
-      setError(validation.error || 'Invalid file');
-      return;
+  const validatePDF = (file: File): boolean => {
+    if (file.type !== 'application/pdf') {
+      toast({ variant: 'destructive', title: 'Invalid file type', description: 'Please select a PDF file' });
+      return false;
     }
+    if (file.size > 10 * 1024 * 1024) {
+      toast({ variant: 'destructive', title: 'File too large', description: 'PDF must be less than 10MB' });
+      return false;
+    }
+    return true;
+  };
 
-    setSelectedFile(file);
-    setError(null);
+  const handleFileSelect = (file: File) => {
+    if (validatePDF(file)) setSelectedFile(file);
   };
 
   const handleFileInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -71,82 +71,50 @@ export const PDFUpload: React.FC<PDFUploadProps> = ({
     setIsDragging(false);
   };
 
-  const uploadFile = async () => {
+  const uploadFileToDB = async () => {
     if (!selectedFile || !eventId) return;
 
-    setIsUploading(true);
-    setError(null);
+    // ponytail: Direct upload + toast, R2 upload + DB update in sequence
+    const result = await upload(selectedFile, { folder: 'events' });
     
-    // Simulate progress for better UX
-    const progressInterval = setInterval(() => {
-      setUploadProgress(prev => {
-        if (prev >= 90) {
-          clearInterval(progressInterval);
-          return 90;
-        }
-        return prev + 10;
-      });
-    }, 200);
+    if (result.success && result.url) {
+      const { error: dbError } = await supabase
+        .from('events')
+        .update({ enquiry_pdf: result.url, enquiry_pdf_path: result.key } as any)
+        .eq('id', eventId);
 
-    try {
-      const result = await uploadEventEnquiryPDF(selectedFile, eventId);
-      
-      clearInterval(progressInterval);
-      setUploadProgress(100);
-      
-      if (result.success && result.url) {
-        toast({
-          title: "PDF uploaded successfully",
-          description: "The enquiry PDF has been attached to the event.",
-        });
-        onUploadComplete?.(result.url, result.path);
-        setSelectedFile(null);
-      } else {
-        setError(result.error || 'Upload failed');
-        toast({
-          title: "Upload failed",
-          description: result.error || 'Failed to upload PDF file',
-          variant: "destructive"
-        });
+      if (dbError) {
+        toast({ title: "Database update failed", description: "File uploaded but couldn't link to event", variant: "destructive" });
+        return;
       }
-    } catch (error) {
-      clearInterval(progressInterval);
-      const errorMessage = 'An unexpected error occurred';
-      setError(errorMessage);
-      toast({
-        title: "Upload failed",
-        description: errorMessage,
-        variant: "destructive"
-      });
-    } finally {
-      setIsUploading(false);
-      setUploadProgress(0);
+      
+      toast({ title: 'Success', description: 'PDF uploaded successfully' });
+      onUploadComplete?.(result.url, result.key);
+      setSelectedFile(null);
+    } else {
+      toast({ variant: 'destructive', title: 'Upload failed', description: result.error || 'Failed to upload PDF' });
     }
   };
 
   const deletePDF = async () => {
     if (!currentPDFUrl || !eventId) return;
 
-    try {
-      const result = await deleteEventEnquiryPDF(eventId, currentPDFUrl);
-      
-      if (result.success) {
-        toast({
-          title: "PDF deleted successfully",
-          description: "The enquiry PDF has been removed from the event.",
-        });
-        onDeleteComplete?.();
-      } else {
-        toast({
-          title: "Delete failed",
-          description: result.error || 'Failed to delete PDF file',
-          variant: "destructive"
-        });
-      }
-    } catch (error) {
+    // ponytail: Just clear DB reference, R2 files are cheap to leave orphaned
+    const { error } = await supabase
+      .from('events')
+      .update({ enquiry_pdf: null, enquiry_pdf_path: null } as any)
+      .eq('id', eventId);
+    
+    if (!error) {
+      toast({
+        title: "PDF removed",
+        description: "The enquiry PDF has been removed from the event.",
+      });
+      onDeleteComplete?.();
+    } else {
       toast({
         title: "Delete failed",
-        description: "An unexpected error occurred",
+        description: "Failed to remove PDF reference",
         variant: "destructive"
       });
     }
@@ -158,7 +126,6 @@ export const PDFUpload: React.FC<PDFUploadProps> = ({
 
   const clearSelectedFile = () => {
     setSelectedFile(null);
-    setError(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
@@ -277,7 +244,7 @@ export const PDFUpload: React.FC<PDFUploadProps> = ({
                 <div className="flex gap-2">
                   <Button
                     size="sm"
-                    onClick={uploadFile}
+                    onClick={uploadFileToDB}
                     disabled={isUploading || disabled}
                   >
                     {isUploading ? 'Uploading...' : 'Upload'}
@@ -299,20 +266,12 @@ export const PDFUpload: React.FC<PDFUploadProps> = ({
               <div className="space-y-2">
                 <div className="flex justify-between text-sm">
                   <span>Uploading...</span>
-                  <span>{uploadProgress}%</span>
+                  <span>{progress}%</span>
                 </div>
-                <Progress value={uploadProgress} className="h-2" />
+                <Progress value={progress} className="h-2" />
               </div>
             )}
           </>
-        )}
-
-        {/* Error Display */}
-        {error && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
         )}
       </CardContent>
     </Card>

--- a/src/components/Events/TeaserVideoManager.tsx
+++ b/src/components/Events/TeaserVideoManager.tsx
@@ -2,8 +2,10 @@ import React, { useState, useRef } from 'react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
-import { Upload, X, Link2, Play, Trash2, Youtube } from 'lucide-react';
+import { Upload, X, Link2, Play, Trash2, Youtube, Loader2 } from 'lucide-react';
 import { Label } from '../ui/label';
+import { useR2Upload } from '@/hooks/useR2Upload';
+import { useToast } from '@/hooks/use-toast';
 
 interface TeaserVideoManagerProps {
   video: string | null;
@@ -19,6 +21,8 @@ export const TeaserVideoManager: React.FC<TeaserVideoManagerProps> = ({
   const [newVideoUrl, setNewVideoUrl] = useState('');
   const [isAddingUrl, setIsAddingUrl] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { upload, isUploading, progress } = useR2Upload();
+  const { toast } = useToast();
 
   const handleAddVideoUrl = () => {
     const trimmedUrl = newVideoUrl.trim();
@@ -29,20 +33,15 @@ export const TeaserVideoManager: React.FC<TeaserVideoManagerProps> = ({
     }
   };
 
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (!file) return;
-
-    if (file.type.startsWith('video/')) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const result = e.target?.result as string;
-        onChange(result);
-      };
-      reader.readAsDataURL(file);
+    if (!file || !file.type.startsWith('video/')) return;
+    const result = await upload(file, { folder: 'events' });
+    if (result.success && result.url) {
+      onChange(result.url);
+    } else {
+      toast({ variant: 'destructive', title: 'Upload failed', description: result.error || 'Failed to upload video' });
     }
-
-    // Reset the file input
     event.target.value = '';
   };
 
@@ -227,11 +226,11 @@ export const TeaserVideoManager: React.FC<TeaserVideoManagerProps> = ({
                     type="button"
                     variant="outline"
                     onClick={() => fileInputRef.current?.click()}
-                    disabled={disabled}
+                    disabled={disabled || isUploading}
                     className="flex items-center gap-2"
                   >
-                    <Upload className="h-4 w-4" />
-                    Upload Video
+                    {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                    {isUploading ? `Uploading ${progress}%` : 'Upload Video'}
                   </Button>
                   <Button
                     type="button"

--- a/src/components/Projects/NewPost/NewPostSection.tsx
+++ b/src/components/Projects/NewPost/NewPostSection.tsx
@@ -13,52 +13,9 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { Save, Sparkles, Settings, Loader2, ChevronsUpDown, Check } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import ProgramSectionsEditor, { SectionItem } from './ProgramSectionsEditor';
+import { uploadToR2 } from '../../../lib/r2-upload';
 
-const isErrorResponse = (data: unknown): data is { error: string } =>
-  typeof data === 'object' && data !== null &&
-  'error' in data && typeof data.error === 'string';
-
-const isSuccessResponse = (data: unknown): data is { url: string } =>
-  typeof data === 'object' && data !== null &&
-  'url' in data && typeof data.url === 'string' &&
-  data.url !== '';
-
-const UPLOAD_TIMEOUT_MS = 30000;
-const uploadFile = async (file: File): Promise<string> => {
-  const formData = new FormData();
-  formData.append('file', file);
-  const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => controller.abort(), UPLOAD_TIMEOUT_MS);
-  let res: Response;
-  try {
-  res = await fetch('/upload', { method: 'POST', body: formData, signal: controller.signal });
-} catch (err) {
-  const name = err instanceof Error ? err.name : Object(err).name;
-  if (name === 'AbortError') {
-    throw new Error('Upload timed out. Please try again.');
-  }
-  throw new Error('Network error during upload');
-} finally {
-  clearTimeout(timeoutId);
-}
-  if (!res.ok) {
-    throw new Error(`Upload failed: server error ${res.status}`);
-  }
-  let data: unknown;
-  try {
-    data = await res.json();
-  } catch {
-    throw new Error('Upload failed: server returned an invalid response');
-  }
-  if (!isSuccessResponse(data)) {
-    if (isErrorResponse(data)) {
-      throw new Error(`Upload failed: ${data.error}`);
-    }
-    throw new Error('Upload failed: invalid response format');
-  }
-
-  return data.url;
-};
+// ponytail: Removed duplicate uploadFile, using shared r2-upload
 
 // Helper function to remove IDs from content recursively
 const removeIds = (obj: Record<string, unknown>): Record<string, unknown> => {
@@ -331,56 +288,40 @@ const NewPostSection = ({ onProgramSaved, editingProgram }: NewPostSectionProps)
     }
   };
 
-  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  // ponytail: One upload handler factory replacing three copies
+  const createProjectUploadHandler = (
+    setUrl: (url: string) => void,
+    setUploading: (v: boolean) => void,
+    setError: (e: string | null) => void,
+    resetKey: () => void,
+    errorMsg: string
+  ) => async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file || uploadingImage) return;
+    if (!file) return;
+    
     try {
-      setUploadingImage(true);
-      setImageUploadError(null);
-      const url = await uploadFile(file);
-      setImageUrl(url);
+      setUploading(true);
+      setError(null);
+      const result = await uploadToR2(file, { folder: 'projects' });
+      if (!result.success || !result.url) throw new Error(result.error || 'Upload failed');
+      setUrl(result.url);
     } catch (err) {
-      setImageUploadError(err instanceof Error ? err.message : 'Image upload failed');
-      setImageInputKey((k) => k + 1);
+      setError(err instanceof Error ? err.message : errorMsg);
+      resetKey();
     } finally {
-      setUploadingImage(false);
+      setUploading(false);
     }
   };
 
-  // Remove handleBannerUpload entirely
-
-  // Add these two
-  const handleDesktopBannerUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file || uploadingDesktopBanner) return;
-    try {
-      setUploadingDesktopBanner(true);
-      setDesktopBannerUploadError(null);
-      const url = await uploadFile(file);
-      setDesktopBannerUrl(url);
-    } catch (err) {
-      setDesktopBannerUploadError(err instanceof Error ? err.message : 'Desktop banner upload failed');
-      setDesktopBannerInputKey((k) => k + 1);
-    } finally {
-      setUploadingDesktopBanner(false);
-    }
-  };
-
-  const handleMobileBannerUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file || uploadingMobileBanner) return;
-    try {
-      setUploadingMobileBanner(true);
-      setMobileBannerUploadError(null);
-      const url = await uploadFile(file);
-      setMobileBannerUrl(url);
-    } catch (err) {
-      setMobileBannerUploadError(err instanceof Error ? err.message : 'Mobile banner upload failed');
-      setMobileBannerInputKey((k) => k + 1);
-    } finally {
-      setUploadingMobileBanner(false);
-    }
-  };
+  const handleImageUpload = createProjectUploadHandler(
+    setImageUrl, setUploadingImage, setImageUploadError, () => setImageInputKey(k => k + 1), 'Image upload failed'
+  );
+  const handleDesktopBannerUpload = createProjectUploadHandler(
+    setDesktopBannerUrl, setUploadingDesktopBanner, setDesktopBannerUploadError, () => setDesktopBannerInputKey(k => k + 1), 'Desktop banner upload failed'
+  );
+  const handleMobileBannerUpload = createProjectUploadHandler(
+    setMobileBannerUrl, setUploadingMobileBanner, setMobileBannerUploadError, () => setMobileBannerInputKey(k => k + 1), 'Mobile banner upload failed'
+  );
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50 p-6">

--- a/src/components/Projects/NewPost/ProgramSectionsEditor.tsx
+++ b/src/components/Projects/NewPost/ProgramSectionsEditor.tsx
@@ -8,82 +8,23 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
 import { Badge } from '../../ui/badge';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../ui/select';
 import { Plus, X, Layers, Loader2 } from 'lucide-react';
+import { uploadToR2 } from '../../../lib/r2-upload';
 
-const hasStringError = (val: unknown): val is { error: string } => {
-  return (
-    typeof val === 'object' &&
-    val !== null &&
-    'error' in val &&
-    typeof (val as { error: unknown }).error === 'string'
-  );
-};
-
-const hasStringUrl = (val: unknown): val is { url: string } => {
-  return (
-    typeof val === 'object' &&
-    val !== null &&
-    'url' in val &&
-    typeof (val as { url: unknown }).url === 'string'
-  );
-};
+// ponytail: Using shared r2-upload
 
 const isImageLike = (val: unknown): val is { id?: string; url?: string } =>
   typeof val === 'object' && val !== null && !Array.isArray(val) &&
   (('url' in val && typeof (val as { url: unknown }).url === 'string') || !('url' in val));
+
 const isSafeUrl = (url: string): boolean => {
   try {
     const parsed = new URL(url);
-    // Explicitly block data: and javascript: URIs
     if (parsed.protocol === 'data:') return false;
     if (parsed.protocol === 'javascript:') return false;
-    // Only allow https and http
     return parsed.protocol === 'https:' || parsed.protocol === 'http:';
   } catch {
     return false;
   }
-};
-const UPLOAD_TIMEOUT_MS = 30000;
-const uploadFile = async (file: File): Promise<string> => {
-  const formData = new FormData();
-  formData.append('file', file);
-  const controller = new AbortController();
-
-  const timeoutId = window.setTimeout(() => {
-    controller.abort();
-  }, UPLOAD_TIMEOUT_MS);
-
-  let res: Response;
-  try {
-    res = await fetch('/upload', { method: 'POST', body: formData, signal: controller.signal, });
-  } catch (err) {
-    if (err instanceof DOMException && err.name === 'AbortError') {
-      throw new Error('Upload timed out. Please try again.');
-    }
-    throw new Error(`Network error: unable to reach upload server (${err instanceof Error ? err.message : String(err)})`);
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  // Try to parse JSON regardless of status, so we can extract error messages
-  let data: unknown;
-  try {
-    data = await res.json();
-  } catch {
-    // Non-JSON response (e.g. HTML error page from a proxy/CDN)
-    throw new Error(`Upload failed (${res.status}): server returned an invalid response`);
-  }
-
-  if (!res.ok) {
-    const errMsg = hasStringError(data) ? data.error : `Upload failed (${res.status})`;
-    throw new Error(errMsg);
-  }
-
-  if (!hasStringUrl(data)) {
-    throw new Error('Upload failed: no URL returned');
-  }
-
-  return data.url;
-
 };
 
 export type SectionItem = {
@@ -139,23 +80,22 @@ const ProgramSectionsEditor = ({ sections, onChange }: ProgramSectionsEditorProp
 
   const setUploading = (key: string, val: boolean) =>
     setUploadingStates((prev) => ({ ...prev, [key]: val }));
-  const handleFileUpload = async (
-    file: File,
-    uploadKey: string,
-    onSuccess: (url: string) => void,
-    errorLabel = 'Upload failed'
-  ) => {
+  
+  // ponytail: Thin wrapper over uploadToR2, state tracking only
+  const handleFileUpload = async (file: File, uploadKey: string, onSuccess: (url: string) => void) => {
     setUploading(uploadKey, true);
     setUploadError(null);
     try {
-      const url = await uploadFile(file);
-      onSuccess(url);
+      const result = await uploadToR2(file, { folder: 'projects' });
+      if (!result.success || !result.url) throw new Error(result.error || 'Upload failed');
+      onSuccess(result.url);
     } catch (err) {
-      setUploadError(err instanceof Error ? err.message : errorLabel);
+      setUploadError(err instanceof Error ? err.message : 'Upload failed');
     } finally {
       setUploading(uploadKey, false);
     }
   };
+
   const availableSectionKeys = ALL_SECTION_KEYS.filter(
     (key) => !sections.some((s) => s.section_key === key)
   );
@@ -286,15 +226,10 @@ const ProgramSectionsEditor = ({ sections, onChange }: ProgramSectionsEditorProp
                     disabled={uploadingStates[`video-${sectionIndex}`]}
                     onChange={(e) => {
                       const file = e.target.files?.[0];
-                      if (file) handleFileUpload(
-                        file,
-                        `video-${sectionIndex}`,
-                        (url) => {
-                          const existing = typeof content.text === 'string' && content.text.trim() ? content.text.trim() : '';
-                          updateContentField(sectionIndex, 'text', existing ? `${existing}, ${url}` : url);
-                        },
-                        'Video upload failed'
-                      );
+                      if (file) handleFileUpload(file, `video-${sectionIndex}`, (url) => {
+                        const existing = typeof content.text === 'string' && content.text.trim() ? content.text.trim() : '';
+                        updateContentField(sectionIndex, 'text', existing ? `${existing}, ${url}` : url);
+                      });
                     }}
                     className="block w-full text-sm text-slate-600 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-purple-50 file:text-purple-700 hover:file:bg-purple-100 cursor-pointer disabled:opacity-50"
                   />
@@ -341,9 +276,8 @@ const ProgramSectionsEditor = ({ sections, onChange }: ProgramSectionsEditorProp
                         disabled={uploadingStates[`intro-img-${sectionIndex}-${idx}`]}
                         onChange={(e) => {
                           const file = e.target.files?.[0];
-                          if (file) {
-                            void handleFileUpload(file, `intro-img-${sectionIndex}-${idx}`, (url) => updateContentField(sectionIndex, 'images', images.map((img, i) => i === idx ? { ...img, url } : img)), 'Image upload failed');}
-                          }}
+                          if (file) void handleFileUpload(file, `intro-img-${sectionIndex}-${idx}`, (url) => updateContentField(sectionIndex, 'images', images.map((img, i) => i === idx ? { ...img, url } : img)));
+                        }}
                         className="flex-1 text-sm text-slate-600 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-purple-50 file:text-purple-700 hover:file:bg-purple-100 cursor-pointer disabled:opacity-50"
                       />
                       {uploadingStates[`intro-img-${sectionIndex}-${idx}`] && (
@@ -402,8 +336,7 @@ const ProgramSectionsEditor = ({ sections, onChange }: ProgramSectionsEditorProp
                   disabled={uploadingStates[`conclusion-img-${sectionIndex}`]}
                  onChange={(e) => {
                   const file = e.target.files?.[0];
-                  if (file) {
-                    void handleFileUpload(file, `conclusion-img-${sectionIndex}`, (url) => updateContentField(sectionIndex, 'image', { url, alt: image.alt }), 'Image upload failed');}
+                  if (file) void handleFileUpload(file, `conclusion-img-${sectionIndex}`, (url) => updateContentField(sectionIndex, 'image', { url, alt: image.alt }));
                   }}
                   className="block w-full text-sm text-slate-600 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-purple-50 file:text-purple-700 hover:file:bg-purple-100 cursor-pointer disabled:opacity-50"
                 />

--- a/src/components/Webite_Blog/shared/useBlogForm.ts
+++ b/src/components/Webite_Blog/shared/useBlogForm.ts
@@ -8,6 +8,7 @@ import { BlogFormData, ValidationErrors, categories, subcategories } from './Blo
 import { SEOSettings, BlogPost } from '../../../types/blog';
 import { useToast } from '../../../hooks/use-toast';
 import { useBlogDrafts } from '../../../hooks/useBlogDrafts';
+import { useR2Upload } from '../../../hooks/useR2Upload';
 
 export const useBlogForm = (initialData?: BlogPost | null) => {
   const [title, setTitle] = useState('');
@@ -28,13 +29,14 @@ export const useBlogForm = (initialData?: BlogPost | null) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
   const { saveDraft } = useBlogDrafts();
+  const { upload, isUploading: isUploadingImage } = useR2Upload();
 
   const editor = useEditor({
     extensions: [
       StarterKit,
       Image.configure({
         inline: true,
-        allowBase64: true,
+        allowBase64: false,
       }),
       Link.configure({
         openOnClick: false,
@@ -202,14 +204,22 @@ export const useBlogForm = (initialData?: BlogPost | null) => {
     return Object.keys(errors).length === 0;
   };
 
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        setFeaturedImage(e.target?.result as string);
-      };
-      reader.readAsDataURL(file);
+    if (!file) return;
+    
+    // ponytail: Direct upload + toast, no wrapper needed
+    if (!file.type.startsWith('image/')) {
+      toast({ variant: 'destructive', title: 'Invalid file type', description: 'Please select an image file' });
+      return;
+    }
+    
+    const result = await upload(file, { folder: 'blogs' });
+    if (result.success && result.url) {
+      setFeaturedImage(result.url);
+      toast({ title: 'Success', description: 'Image uploaded successfully' });
+    } else {
+      toast({ variant: 'destructive', title: 'Upload failed', description: result.error || 'Failed to upload image' });
     }
   };
 
@@ -324,6 +334,7 @@ export const useBlogForm = (initialData?: BlogPost | null) => {
     lastSaved,
     validationErrors,
     showValidation, setShowValidation,
+    isUploadingImage,
     
     // Refs
     fileInputRef,

--- a/src/hooks/useR2Upload.ts
+++ b/src/hooks/useR2Upload.ts
@@ -1,0 +1,44 @@
+// ponytail: React hook wrapping R2 upload with state management
+import { useState, useCallback } from 'react';
+import { uploadToR2, type R2UploadResult, type R2UploadOptions } from '@/lib/r2-upload';
+
+export interface UseR2UploadState {
+  isUploading: boolean;
+  progress: number;
+  error: string | null;
+  result: R2UploadResult | null;
+}
+
+export function useR2Upload() {
+  const [state, setState] = useState<UseR2UploadState>({
+    isUploading: false,
+    progress: 0,
+    error: null,
+    result: null,
+  });
+
+  const upload = useCallback(async (file: File, options?: R2UploadOptions) => {
+    // ponytail: validation now in uploadToR2, no need to call twice
+    setState({ isUploading: true, progress: 0, error: null, result: null });
+
+    const result = await uploadToR2(file, {
+      ...options,
+      onProgress: (percent) => setState(prev => ({ ...prev, progress: percent })),
+    });
+
+    setState({
+      isUploading: false,
+      progress: result.success ? 100 : 0,
+      error: result.error || null,
+      result,
+    });
+
+    return result;
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({ isUploading: false, progress: 0, error: null, result: null });
+  }, []);
+
+  return { ...state, upload, reset };
+}

--- a/src/lib/r2-upload.ts
+++ b/src/lib/r2-upload.ts
@@ -1,0 +1,93 @@
+// ponytail: Direct POST to Worker, no presigned URLs (avoids CORS issues)
+// Worker proxies to R2 with proper CORS headers
+
+import { ALLOWED_TYPES, MAX_SIZE_MB, MAX_SIZE_BYTES } from './upload-config';
+
+export interface R2UploadOptions {
+  onProgress?: (percent: number) => void;
+  folder?: string; // events, projects, blogs, etc.
+}
+
+export interface R2UploadResult {
+  success: boolean;
+  url?: string;
+  key?: string;
+  error?: string;
+}
+
+/**
+ * Upload file to R2 via Worker proxy
+ */
+export async function uploadToR2(
+  file: File,
+  options: R2UploadOptions = {}
+): Promise<R2UploadResult> {
+  try {
+    // ponytail: validation extracted to single function
+    const validation = validateFile(file);
+    if (!validation.valid) {
+      return { success: false, error: validation.error };
+    }
+
+    // Upload to Worker endpoint with progress tracking
+    const xhr = new XMLHttpRequest();
+    
+    const uploadPromise = new Promise<{ url: string; key: string }>((resolve, reject) => {
+      xhr.upload.addEventListener('progress', (e) => {
+        if (e.lengthComputable && options.onProgress) {
+          options.onProgress(Math.round((e.loaded / e.total) * 100));
+        }
+      });
+      
+      xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            const response = JSON.parse(xhr.responseText);
+            if (response.url) {
+              resolve({ url: response.url, key: response.key });
+            } else {
+              reject(new Error(response.error || 'No URL in response'));
+            }
+          } catch (err) {
+            reject(new Error('Invalid JSON response'));
+          }
+        } else {
+          try {
+            const response = JSON.parse(xhr.responseText);
+            reject(new Error(response.error || `Upload failed (${xhr.status})`));
+          } catch {
+            reject(new Error(`Upload failed (${xhr.status})`));
+          }
+        }
+      });
+      
+      xhr.addEventListener('error', () => reject(new Error('Network error')));
+      xhr.addEventListener('abort', () => reject(new Error('Upload cancelled')));
+
+      const folderParam = options.folder ? `&folder=${encodeURIComponent(options.folder)}` : '';
+      const url = `/upload?filename=${encodeURIComponent(file.name)}${folderParam}`;
+      xhr.open('POST', url);
+      xhr.setRequestHeader('Content-Type', file.type);
+      xhr.send(file);
+    });
+
+    const { url, key } = await uploadPromise;
+    return { success: true, url, key };
+
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : 'Upload failed' };
+  }
+}
+
+/**
+ * Validate file before upload
+ */
+export function validateFile(file: File): { valid: boolean; error?: string } {
+  if (!ALLOWED_TYPES.includes(file.type as typeof ALLOWED_TYPES[number])) {
+    return { valid: false, error: `File type ${file.type} not supported` };
+  }
+  if (file.size > MAX_SIZE_BYTES) {
+    return { valid: false, error: `File must be under ${MAX_SIZE_MB}MB` };
+  }
+  return { valid: true };
+}

--- a/src/lib/upload-config.ts
+++ b/src/lib/upload-config.ts
@@ -1,0 +1,11 @@
+// ponytail: Single source of truth for upload constraints (client & server)
+export const ALLOWED_TYPES = [
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+  'video/mp4', 'video/webm', 'video/quicktime',
+  'application/pdf'
+] as const;
+
+export type AllowedType = typeof ALLOWED_TYPES[number];
+
+export const MAX_SIZE_MB = 100;
+export const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,19 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      // Proxy /upload to Cloudflare Worker during local dev
+      '/upload': {
+        target: 'http://localhost:8788',
+        changeOrigin: true,
+        // Preserve Origin header for CORS
+        configure: (proxy, _options) => {
+          proxy.on('proxyReq', (proxyReq, req, _res) => {
+            proxyReq.setHeader('Origin', 'http://localhost:8080');
+          });
+        },
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
- Eliminate ~200 lines of duplicate code across upload system
- Remove unnecessary useMediaUpload abstraction layer
- Create upload-config.ts as single source of truth
- Add DRY helpers to Worker (errorResponse, checkEnvVars, etc.)
- Consolidate validation logic and error handling